### PR TITLE
Fix buffer overflow in file_browser.c

### DIFF
--- a/file_browser.c
+++ b/file_browser.c
@@ -63,9 +63,7 @@ void Thoth_FileBrowser_ChangeDirectory(Thoth_FileBrowser *fb){
 
 		struct stat s;
 		char temp[MAX_PATH_LEN];
-		strcpy(temp,fb->directory);
-		strcpy(&temp[strlen(temp)], dp->d_name);
-		
+		snprintf(temp, MAX_PATH_LEN, "%s%s", fb->directory, dp->d_name);
 		stat(temp, &s);
 
 		if((s.st_mode & S_IFMT) == S_IFDIR){


### PR DESCRIPTION
### Bug: file_browser.c: Stack buffer overflow via `strcpy` (L66, 67)

**Impact:** A stack-based buffer overflow can lead to memory corruption, potentially causing denial of service or arbitrary code execution.

**Vulnerable Code:**
```c
		strcpy(temp,fb->directory);
		strcpy(&temp[strlen(temp)], dp->d_name);
```

**Proposed Fix:**
```c
		snprintf(temp, MAX_PATH_LEN, "%s%s", fb->directory, dp->d_name);
```